### PR TITLE
Add ion-java performance regression detector to GitHub workflow

### DIFF
--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -1,0 +1,61 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Ion Jave performance regression detector
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build-ion-java:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+
+
+        with:
+          fetch-depth: 2
+          submodules: recursive
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - run: git checkout HEAD^
+      - run: mvn clean install
+
+
+
+      - uses: actions/checkout@v2
+        with:
+          repository: amzn/ion-java-benchmark-cli
+          ref: master
+
+      - name: Build with Maven
+        run: mvn clean install
+      - name: Verify the CLI executes
+        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
+      - name: clean maven repository
+        run : rm -r /home/runner/.m2
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - run: mvn clean install
+
+      - uses: actions/checkout@v2
+        with:
+          repository: amzn/ion-java-benchmark-cli
+          ref: master
+
+      - name: Build with Maven
+        run: mvn clean install
+      - name: Verify the CLI executes
+        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version

--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -38,7 +38,7 @@ jobs:
           ref: master
       - run: mvn clean install
 
-      - name: Check the version of ion-java and ion-java-benchmark-cli
+      - name: Check the version of ion-java
         run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
 
       - name: Generate test Ion Data
@@ -46,7 +46,6 @@ jobs:
 
       - name: Test read preformance of the ion-java from the current commit
         run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar read testWorkflow.ion -o readPerformanceCurrent.ion -r ion
-
 
       - name: Clean maven dependency repository
         run : rm -r /home/runner/.m2
@@ -66,7 +65,7 @@ jobs:
           ref: master
       - run: mvn clean install
 
-      - name: Check the version of ion-java and ion-java-benchmark-cli
+      - name: Check the version of ion-java
         run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
 
       - name: Test read preformance of ion-java from the new commit

--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -6,56 +6,68 @@ name: Ion Jave performance regression detector
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
-  build-ion-java:
+  detetct-regression:
+    name: Detetct Regression
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
 
-
-
+      - name: Checkout ion-java repository from the current commit
+        uses: actions/checkout@v2
         with:
           fetch-depth: 2
           submodules: recursive
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
       - run: git checkout HEAD^
-      - run: mvn clean install
 
+      - name: Build ion-java from the current commit
+        run: mvn clean install
 
-
-      - uses: actions/checkout@v2
+      - name: Build ion-java-benchmark-cli based on the current ion-java
+        uses: actions/checkout@v2
         with:
           repository: amzn/ion-java-benchmark-cli
           ref: master
+      - run: mvn clean install
 
-      - name: Build with Maven
-        run: mvn clean install
-      - name: Verify the CLI executes
+      - name: Check the version of ion-java and ion-java-benchmark-cli
         run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
-      - name: clean maven repository
+
+      - name: Generate test Ion Data
+        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar generate -S 500 -T string -f ion_text testWorkflow.ion
+
+      - name: Test read preformance of the ion-java from the current commit
+        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar read testWorkflow.ion -o readPerformanceCurrent.ion -r ion
+
+
+      - name: Clean maven dependency repository
         run : rm -r /home/runner/.m2
 
-      - uses: actions/checkout@v2
+      - name: Checkout ion-java repository from the new commit
+        uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-      - run: mvn clean install
 
-      - uses: actions/checkout@v2
+      - name: Build ion-java from the new commit
+        run: mvn clean install
+
+      - name: Build ion-java-benchmark-cli based on the new ion-java
+        uses: actions/checkout@v2
         with:
           repository: amzn/ion-java-benchmark-cli
           ref: master
+      - run: mvn clean install
 
-      - name: Build with Maven
-        run: mvn clean install
-      - name: Verify the CLI executes
+      - name: Check the version of ion-java and ion-java-benchmark-cli
         run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
+
+      - name: Test read preformance of ion-java from the new commit
+        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar read testWorkflow.ion -o readPerformanceNew.ion -r ion


### PR DESCRIPTION
*Description of changes:*

Workflow review guide: 
This PR add the ability to build both ion-java and ion-java-benchmark-cli from the new commit and the previous commit when the new commit has been pushed. This is the first step of detecting ion-java performance regression. This workflow will be triggered when the action 'push commit to master branch' starts.
Step 1: 
Checkout ion-java repository from the current commit(The one before push action happened) the build ion-java on GitHub host runner. 
Step 2:
Checkout ion-java-benchmark-cli repository then build ion-java-benchmark-cli under the same host as ion-java.
Step 3: 
Check the version of ion-java and ion-java-benchmark-cli by run:  java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
This step will help to check whether the requested version of ion-java has been built.
Step 4: 
Delete /.m2/repository which contains all dependencies from the last round build.
Step 5:
Checkout the ion-java-repository under the new commit(The commit pushed by developers) and build ion-java on the same host runner as the last build process.
Step 6: 
Build ion-java-benchmark-cli again then check the version of ion-java to make sure the most recent ion-java has been under the benchmark process.
