### PR TITLE
Adds the ability to detect ion-java performance regression in GitHub workflow

### DIFF
--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Ion Jave performance regression detector
+name: Ion Java performance regression detector
 
 on:
   push:
@@ -10,8 +10,8 @@ on:
     branches: [ master ]
 
 jobs:
-  detetct-regression:
-    name: Detetct Regression
+  detect-regression:
+    name: Detect Regression
 
     runs-on: ubuntu-latest
 
@@ -21,44 +21,46 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: Checkout the ion-java from the existing commit.
+      - name: Checkout ion-java from the new commit.
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
           submodules: recursive
-          run: git checkout HEAD^
+          path: ion-java
 
-      - name: Build ion-java based on the existing commit
-        run: mvn clean install
+      - name: Build ion-java from the new commit
+        run: cd ion-java && mvn clean install
 
       - name: Checkout ion-java-benchmark-cli
         uses: actions/checkout@v2
         with:
           repository: linlin-s/ion-java-benchmark-cli
-          ref: final
+          ref: swap
+          path: ion-java-benchmark-cli
 
-      - name: Build ion-java-benchmark-cli based on the current ion-java
-        run: mvn clean install
+      - name: Build ion-java-benchmark-cli
+        run: cd ion-java-benchmark-cli && mvn clean install
 
-      - name: Check the version of ion-java
-        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
+      - name: Check the version of ion-java.
+        run: java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
 
       - name: Generate test Ion Data
         run: |
           mkdir -p testData
-          java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 5000 --input-ion-schema ./tst/com/amazon/ion/benchmark/testStruct.isl /home/runner/work/ion-java/ion-java/testData/testStruct.10n
-          java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 5000 --input-ion-schema ./tst/com/amazon/ion/benchmark/testList.isl /home/runner/work/ion-java/ion-java/testData/testList.10n
-          java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 5000 --input-ion-schema ./tst/com/amazon/ion/benchmark/testNestedStruct.isl /home/runner/work/ion-java/ion-java/testData/testNestedStruct.10n
-      - name: Upload test Ion Data to artifact
+          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/benchmark/testStruct.isl testData/testStruct.10n
+          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/benchmark/testList.isl testData/testList.10n
+          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/benchmark/testNestedStruct.isl testData/testNestedStruct.10n
+
+      - name: Upload test Ion Data to artifacts
         uses: actions/upload-artifact@v2
         with:
           name: test Ion Data
           path: testData
 
-      - name: Benchmark ion-java from the existing commit
+      - name: Benchmark ion-java from the new commit
         run: |
           mkdir -p benchmarkResults
-          java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar organize --test-ion-data /home/runner/work/ion-java/ion-java/testData /home/runner/work/ion-java/ion-java/benchmarkResults
+          cd ion-java-benchmark-cli && java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar run-suite --test-ion-data /home/runner/work/ion-java/ion-java/testData --benchmark-options-combinations tst/com/amazon/ion/benchmark/optionsCombinations.ion /home/runner/work/ion-java/ion-java/benchmarkResults
 
       - name: Upload benchmark results to artifacts
         uses: actions/upload-artifact@v2
@@ -66,50 +68,39 @@ jobs:
           name: Benchmark result
           path: benchmarkResults
 
-      - name: Clean maven dependency repository
+      - name: Clean maven dependencies repository
         run : rm -r /home/runner/.m2
 
-      - name: Checkout ion-java repository from the new commit
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      - name: Build ion-java from the previous commit
+        run: cd ion-java && git checkout HEAD^ && mvn clean install
 
-      - name: Build ion-java from the new commit
-        run: mvn clean install
-
-      - name: Checkout ion-java-benchmark-cli
-        uses: actions/checkout@v2
-        with:
-          repository: linlin-s/ion-java-benchmark-cli
-          ref: final
-
-      - name: Build ion-java-benchmark-cli based on the new ion-java
-        run: mvn clean install
+      - name: Build ion-java-benchmark-cli
+        run: cd ion-java-benchmark-cli && mvn clean install
 
       - name: Check the version of ion-java
-        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
+        run: java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
 
       - name: Create directories for test data and benchmark results
         run: |
           mkdir -p benchmarkResults
           mkdir -p testData
 
-      - name: Download test Ion Data to artifact
+      - name: Download test Ion Data from artifacts
         uses: actions/download-artifact@v2
         with:
           name: test Ion Data
           path: testData
 
-      - name: Download benchmark results of ion-java from the existing commit to artifact
+      - name: Download benchmark results of ion-java from the new commit from artifacts
         uses: actions/download-artifact@v2
         with:
           name: Benchmark result
           path: benchmarkResults
 
-      - name: Benchmark ion-java from the new commit and add the generated benchmark result to the existing directory
-        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar organize --test-ion-data /home/runner/work/ion-java/ion-java/testData /home/runner/work/ion-java/ion-java/benchmarkResults
+      - name: Benchmark ion-java from the previous commit and add the generated benchmark results to the existing directories
+        run: cd ion-java-benchmark-cli && java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar run-suite --test-ion-data /home/runner/work/ion-java/ion-java/testData --benchmark-options-combinations tst/com/amazon/ion/benchmark/optionsCombinations.ion /home/runner/work/ion-java/ion-java/benchmarkResults
 
-      - name: Upload new benchmark results directory to artifact
+      - name: Upload new benchmark results directory to artifacts
         uses: actions/upload-artifact@v2
         with:
           name: Benchmark result
@@ -118,10 +109,10 @@ jobs:
       - name: Detect performance regression
         id: regression_result
         run: |
-          cd benchmarkResults
           result=true
-          for FILE in *; do message=$(java -jar /home/runner/work/ion-java/ion-java/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar compare --benchmark-result-previous $FILE/previous.ion --benchmark-result-new $FILE/new.ion --threshold /home/runner/work/ion-java/ion-java/tst/com/amazon/ion/benchmark/threshold.ion $FILE/report.ion | tee /dev/stderr) &&if [ "$message" != "Regression not detected" ]; then result=false;fi; done
+          cd benchmarkResults && for FILE in *; do message=$(java -jar /home/runner/work/ion-java/ion-java/ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar compare --benchmark-result-previous $FILE/previous.ion --benchmark-result-new $FILE/new.ion $FILE/report.ion | tee /dev/stderr) && if [ "$message" != "" ]; then result=false; fi; done
           echo "::set-output name=regression-result::$result"
+          echo $result
 
       - name: Upload comparison reports to the benchmark results directory
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -21,31 +21,50 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: Checkout ion-java repository from the current commit
+      - name: Checkout the ion-java from the existing commit.
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
           submodules: recursive
-      - run: git checkout HEAD^
+          run: git checkout HEAD^
 
-      - name: Build ion-java from the current commit
+      - name: Build ion-java based on the existing commit
         run: mvn clean install
 
-      - name: Build ion-java-benchmark-cli based on the current ion-java
+      - name: Checkout ion-java-benchmark-cli
         uses: actions/checkout@v2
         with:
-          repository: amzn/ion-java-benchmark-cli
-          ref: master
-      - run: mvn clean install
+          repository: linlin-s/ion-java-benchmark-cli
+          ref: final
+
+      - name: Build ion-java-benchmark-cli based on the current ion-java
+        run: mvn clean install
 
       - name: Check the version of ion-java
         run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
 
       - name: Generate test Ion Data
-        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar generate -S 500 -T string -f ion_text testWorkflow.ion
+        run: |
+          mkdir -p testData
+          java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 5000 --input-ion-schema ./tst/com/amazon/ion/benchmark/testStruct.isl /home/runner/work/ion-java/ion-java/testData/testStruct.10n
+          java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 5000 --input-ion-schema ./tst/com/amazon/ion/benchmark/testList.isl /home/runner/work/ion-java/ion-java/testData/testList.10n
+          java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 5000 --input-ion-schema ./tst/com/amazon/ion/benchmark/testNestedStruct.isl /home/runner/work/ion-java/ion-java/testData/testNestedStruct.10n
+      - name: Upload test Ion Data to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: test Ion Data
+          path: testData
 
-      - name: Test read preformance of the ion-java from the current commit
-        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar read testWorkflow.ion -o readPerformanceCurrent.ion -r ion
+      - name: Benchmark ion-java from the existing commit
+        run: |
+          mkdir -p benchmarkResults
+          java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar organize --test-ion-data /home/runner/work/ion-java/ion-java/testData /home/runner/work/ion-java/ion-java/benchmarkResults
+
+      - name: Upload benchmark results to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Benchmark result
+          path: benchmarkResults
 
       - name: Clean maven dependency repository
         run : rm -r /home/runner/.m2
@@ -58,15 +77,60 @@ jobs:
       - name: Build ion-java from the new commit
         run: mvn clean install
 
-      - name: Build ion-java-benchmark-cli based on the new ion-java
+      - name: Checkout ion-java-benchmark-cli
         uses: actions/checkout@v2
         with:
-          repository: amzn/ion-java-benchmark-cli
-          ref: master
-      - run: mvn clean install
+          repository: linlin-s/ion-java-benchmark-cli
+          ref: final
+
+      - name: Build ion-java-benchmark-cli based on the new ion-java
+        run: mvn clean install
 
       - name: Check the version of ion-java
         run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
 
-      - name: Test read preformance of ion-java from the new commit
-        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar read testWorkflow.ion -o readPerformanceNew.ion -r ion
+      - name: Create directories for test data and benchmark results
+        run: |
+          mkdir -p benchmarkResults
+          mkdir -p testData
+
+      - name: Download test Ion Data to artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: test Ion Data
+          path: testData
+
+      - name: Download benchmark results of ion-java from the existing commit to artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: Benchmark result
+          path: benchmarkResults
+
+      - name: Benchmark ion-java from the new commit and add the generated benchmark result to the existing directory
+        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar organize --test-ion-data /home/runner/work/ion-java/ion-java/testData /home/runner/work/ion-java/ion-java/benchmarkResults
+
+      - name: Upload new benchmark results directory to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Benchmark result
+          path: benchmarkResults
+
+      - name: Detect performance regression
+        id: regression_result
+        run: |
+          cd benchmarkResults
+          result=true
+          for FILE in *; do message=$(java -jar /home/runner/work/ion-java/ion-java/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar compare --benchmark-result-previous $FILE/previous.ion --benchmark-result-new $FILE/new.ion --threshold /home/runner/work/ion-java/ion-java/tst/com/amazon/ion/benchmark/threshold.ion $FILE/report.ion | tee /dev/stderr) &&if [ "$message" != "Regression not detected" ]; then result=false;fi; done
+          echo "::set-output name=regression-result::$result"
+
+      - name: Upload comparison reports to the benchmark results directory
+        uses: actions/upload-artifact@v2
+        with:
+          name: Benchmark result
+          path: benchmarkResults
+
+      - name: Fail the workflow if regression happened
+        env:
+          regression_detect: ${{steps.regression_result.outputs.regression-result}}
+        if: ${{ env.regression_detect == 'false' }}
+        run: exit 1

--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Checkout ion-java-benchmark-cli
         uses: actions/checkout@v2
         with:
-          repository: linlin-s/ion-java-benchmark-cli
-          ref: swap
+          repository: amzn/ion-java-benchmark-cli
+          ref: master
           path: ion-java-benchmark-cli
 
       - name: Build ion-java-benchmark-cli


### PR DESCRIPTION
*Description of changes:*

This PR adds the ability to detect the performance regression of ion-java from the new commit.

**Review guide:**

1. Lines 47- 56:
After building ion-java and ion-java-benchmark-cli, more steps were added to generate test Ion data which will be used in benchmark process and be uploaded to artifacts.

2. Lines 58 - 67:
Get benchmark results of ion-java from the existing commit by using the test data generated from the last step and save these results into one directory named benchmarkResults, then upload the directory to artifacts.

3. Lines 92 - 107:
Download the data from artifacts and save them into the directory with the same file name as the one during the uploading process.

4. Lines 109 - 116:
Get benchmark results of ion-java from the new commit and add them in to the existing directory benchmarkResults, then upload the directory with additional benchmark results to artifacts.

5.  Lines 118 - 124:
Inside of the directory benchmarkResults, benchmark results from the same ion-java-benchmark-invoke will be saved to the same sub-directory named with the command line. This step will iterate all sub-directories in benchmarkResults and use API 'compare' to detect if performance regression happened. There variable $result will be set to 'false' if performance regression happened during the iteration process.

6. Lines 126 - 130:
After using API 'compare', one comparison report will be generated under each sub-directory in benchmarkResults. This step upload the final results with additional comparison reports to artifacts.

7. Lines 132 - 136:
Get variable $result from the previous step, if this value equal to 'false' then the performance regression detected, the workflow should be failed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.